### PR TITLE
Merge

### DIFF
--- a/lib/bplustree.c
+++ b/lib/bplustree.c
@@ -314,7 +314,7 @@ parent_node_build(struct bplus_tree *tree, struct bplus_node *l_ch,
                 /* release parent, left and right child */
                 node_release(tree, l_ch);
                 node_release(tree, r_ch);
-                node_release(tree, parent);
+                cache_defer(tree, parent);
                 return 0;
         } else if (r_ch->parent == INVALID_OFFSET) {
                 r_ch->parent = l_ch->parent;

--- a/lib/bplustree.h
+++ b/lib/bplustree.h
@@ -86,7 +86,8 @@ typedef struct bplus_node {
         int type;
         int parent_key_idx;
         int count;
-        int reserve;
+        /* used in bplus_tree_dump, mark the node has been already pushed. */
+        int pushed;
 } bplus_node;
 /*
 struct bplus_non_leaf {


### PR DESCRIPTION
1.  commit --- Don't write parent node twice.
Slight change, since root has been written in new_node_write, no need to write it again.

2. commit ---  Don't read the node already in the stack.
Changes a lot. When dump a bplustree, the way --- keep node_backlog in the stack seems inefficent.
node_seek may read a parent node for many times. Just keep the bplus_node points in the stack is more efficent, we only need to read the node on disk once.



