### PR TITLE
No need to go down when the key exits in parent node

### DIFF
--- a/lib/bplustree.c
+++ b/lib/bplustree.c
@@ -633,12 +633,12 @@ bplus_tree_insert(struct bplus_tree *tree, int key, long data)
                         return leaf_insert(tree, node, key, data);
                 } else {
                         int i = key_binary_search(node, key);
-                        if (i >= 0) {
-                                node = node_seek(tree, sub(node)[i + 1]);
-                        } else {
+                        if (i < 0) {
                                 i = -i - 1;
                                 node = node_seek(tree, sub(node)[i]);
+                                continue;
                         }
+                        return -1;
                 }
         }
 


### PR DESCRIPTION
If the key which we want to insert already exits in its parents' node, there is no need to go down and search in the leaf node, because the key in the parents nodes are fetched from their leaf node.