### PR TITLE
fix memory leak because forget to free root.

### DIFF
--- a/lib/bplustree.c
+++ b/lib/bplustree.c
@@ -828,7 +828,7 @@ struct bplus_tree *bplus_tree_init(int order, int entries)
 void bplus_tree_deinit(struct bplus_tree *tree)
 {
     int i;
-    for(i=0; i<tree->level; i++)
+    for(i=0; i<=tree->level; i++)
     {
         struct list_head *cur, *next;
         list_for_each_safe(cur, next, &tree->list[i])


### PR DESCRIPTION
When the true height of the tree is n, tree->level equals n-1.  I didn't free the root in yesterday's submission. Sry.

Thanks for your elegant code, I learned a lot in it. But I have a question about tree->level:
As just said, tree->level always equals true height - 1. What is the meaning of such a design? If this is a bug, I‘m willing to fix it.