### PR TITLE
Fix did not close fd in function bplus_tree_deinit()

### DIFF
--- a/lib/bplustree.c
+++ b/lib/bplustree.c
@@ -1141,6 +1141,7 @@ void bplus_tree_deinit(struct bplus_tree *tree)
                 free(block);
         }
 
+        close(fd);
         bplus_close(tree->fd);
         free(tree->caches);
         free(tree);


### PR DESCRIPTION
In function bplus_tree_deinit(), we open the *.boot file but not close the fd, it will appear errno: 24(Too many open files) when reuse init and deinit about 1000 times.